### PR TITLE
open the nav item page when clicked + toggle it

### DIFF
--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -26,8 +26,10 @@ $(function () {
 
     // Toggle when click an item element
     $('.navigation').on('click', '.title', function (e) {
-        $(this).parent().find('.itemMembers').toggle();
-        e.preventDefault();
+        var lst = $(this).parent().find('li');
+        if (lst.length > 0) {
+            $(this).parent().find('.itemMembers').toggle();
+        }
     });
 
     // Show an item related a current documentation automatically


### PR DESCRIPTION
Before this patch, it's not possible to view the module page, whenever clicked on the module in the nav bar, it just opens the list.
